### PR TITLE
Fix config

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,3 @@
-excluded:
-  - **/*+Generated.swift
-  - **/Ampli.swift
-
 disabled_rules:
   - discarded_notification_center_observer
   - notification_center_detachment
@@ -70,6 +66,10 @@ function_body_length:
     warning: 60
 
 legacy_hashing: error
+
+type_name:
+  max_length:
+    warning: 60
 
 identifier_name:
   max_length:


### PR DESCRIPTION
I think it makes more sense to exclude files absolutely per project as this exclusion list will have to be overridden per project anyway.
I have also added type length to match identifier length