### PR TITLE
Fix conflicting disabled and opt_in rules for attributes and indentation_width

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,9 +4,8 @@ disabled_rules:
   - orphaned_doc_comment
   - todo
   - unused_capture_list
-  - attributes
-  - indentation_width
   - function_parameter_count
+  - blanket_disable_command
 
 analyzer_rules:
   - unused_import


### PR DESCRIPTION
## Summary

- Remove `attributes and indentation_width` from `disabled_rules`
- Add `blanket_disable_command to disabled_rules`

This accompanies a ElectroverseConsumer PR https://github.com/octopus-energy/ElectroverseConsumerMobile/pull/17816

## Why

`attributes` and `indentation_width` were listed in both `disabled_rules` and `opt_in_rules`, with configuration defined for each. This caused SwiftLint to emit warnings:
```
Found a configuration for 'attributes' rule, but it is disabled in 'disabled_rules'.
Found a configuration for 'indentation_width' rule, but it is disabled in 'disabled_rules'.
```
Removing them from `disabled_rules` allows the `opt-in` rules and their configurations to take effect as intended.

`blanket_disable_command` is disabled to allow generated files (e.g., SwiftGen's Strings+Generated.swift) to use
```
// swiftlint:disable all 
```
without triggering violations.

## Dependencies
This change on its own wont sync without a local `swiftlint` call to update local caches, so once this is merged and a new tag created I will let everyone know to sync.