### PR TITLE
Remove unused_capture_list rule from SwiftLint config

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,7 +3,6 @@ disabled_rules:
   - notification_center_detachment
   - orphaned_doc_comment
   - todo
-  - unused_capture_list
   - function_parameter_count
   - blanket_disable_command
 


### PR DESCRIPTION
`unused_capture_list` was removed in 0.58.0 https://github.com/realm/SwiftLint/blob/main/CHANGELOG.md#0580-new-years-fresh-fold