### PR TITLE
Disable pattern matching keywords

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
   - todo
   - function_parameter_count
   - blanket_disable_command
+  - pattern_matching_keywords
 
 analyzer_rules:
   - unused_import


### PR DESCRIPTION
This PR disables the rule that caused [this](https://github.com/octopus-energy/ElectroverseConsumerMobile/pull/20620/changes) PR

I personally believe the rule is worse as the value binding is more readable and obvious when next to the variable it is associated with.  